### PR TITLE
Fix init.go version key and add test

### DIFF
--- a/cmd/gortex/commands/init.go
+++ b/cmd/gortex/commands/init.go
@@ -31,15 +31,15 @@ func initProject(basePath, projectName string, withExamples bool) error {
 	}
 
 	if err := generateFile(filepath.Join(basePath, "go.mod"), goModTemplate, map[string]string{
-		"ModuleName": moduleName,
-		"STMPVersion": "v0.1.10",
+		"ModuleName":    moduleName,
+		"GORTEXVersion": rootCmd.Version,
 	}); err != nil {
 		return err
 	}
 
 	// Generate main.go
 	if err := generateFile(filepath.Join(basePath, "cmd/server/main.go"), mainTemplate, map[string]string{
-		"ModuleName": moduleName,
+		"ModuleName":  moduleName,
 		"ProjectName": projectName,
 	}); err != nil {
 		return err
@@ -73,7 +73,7 @@ func initProject(basePath, projectName string, withExamples bool) error {
 	// Generate README
 	if err := generateFile(filepath.Join(basePath, "README.md"), projectReadmeTemplate, map[string]string{
 		"ProjectName": projectName,
-		"ModuleName": moduleName,
+		"ModuleName":  moduleName,
 	}); err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func initProject(basePath, projectName string, withExamples bool) error {
 func generateExamples(basePath, moduleName string) error {
 	// Create example handlers
 	exampleHandlersPath := filepath.Join(basePath, "handlers")
-	
+
 	if err := generateFile(filepath.Join(exampleHandlersPath, "user.go"), userHandlerTemplate, map[string]string{
 		"ModuleName": moduleName,
 	}); err != nil {
@@ -125,7 +125,7 @@ func generateExamples(basePath, moduleName string) error {
 
 	// Create example services
 	exampleServicesPath := filepath.Join(basePath, "services")
-	
+
 	if err := generateFile(filepath.Join(exampleServicesPath, "user_service.go"), userServiceTemplate, map[string]string{
 		"ModuleName": moduleName,
 	}); err != nil {
@@ -134,7 +134,7 @@ func generateExamples(basePath, moduleName string) error {
 
 	// Create example models
 	exampleModelsPath := filepath.Join(basePath, "models")
-	
+
 	if err := generateFile(filepath.Join(exampleModelsPath, "user.go"), userModelTemplate, map[string]string{
 		"ModuleName": moduleName,
 	}); err != nil {

--- a/cmd/gortex/commands/init_test.go
+++ b/cmd/gortex/commands/init_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitProject_GoModVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	rootCmd = &cobra.Command{Version: "v0.1.10"}
+
+	err := initProject(tmpDir, "testapp", false)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "go.mod"))
+	require.NoError(t, err)
+
+	require.Contains(t, string(data), "github.com/yshengliao/gortex v0.1.10")
+}


### PR DESCRIPTION
## Summary
- update `init.go` to use `GORTEXVersion` instead of `STMPVersion`
- pass CLI version from `rootCmd` when generating `go.mod`
- add a unit test verifying the generated `go.mod` contains the correct Gortex version

## Testing
- `go test ./cmd/... -run TestInitProject_GoModVersion -v`
- `go test ./...` *(fails: TestAuthExample and TestHTTPHealthCheck)*

------
https://chatgpt.com/codex/tasks/task_b_687f1f5ae368832dacb0ecfe94726aae