### PR TITLE
Add ShutdownTimeout server config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,14 +18,15 @@ type Config struct {
 
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
-	Port         string        `yaml:"port" env:"PORT" default:"8080"`
-	Address      string        `yaml:"address" env:"ADDRESS" default:":8080"`
-	ReadTimeout  time.Duration `yaml:"read_timeout" env:"READ_TIMEOUT" default:"30s"`
-	WriteTimeout time.Duration `yaml:"write_timeout" env:"WRITE_TIMEOUT" default:"30s"`
-	IdleTimeout  time.Duration `yaml:"idle_timeout" env:"IDLE_TIMEOUT" default:"120s"`
-	GZip         bool          `yaml:"gzip" env:"GZIP" default:"true"`
-	CORS         bool          `yaml:"cors" env:"CORS" default:"true"`
-	Recovery     bool          `yaml:"recovery" env:"RECOVERY" default:"true"`
+	Port            string        `yaml:"port" env:"PORT" default:"8080"`
+	Address         string        `yaml:"address" env:"ADDRESS" default:":8080"`
+	ReadTimeout     time.Duration `yaml:"read_timeout" env:"READ_TIMEOUT" default:"30s"`
+	WriteTimeout    time.Duration `yaml:"write_timeout" env:"WRITE_TIMEOUT" default:"30s"`
+	IdleTimeout     time.Duration `yaml:"idle_timeout" env:"IDLE_TIMEOUT" default:"120s"`
+	ShutdownTimeout time.Duration `yaml:"shutdown_timeout" env:"SHUTDOWN_TIMEOUT" default:"10s"`
+	GZip            bool          `yaml:"gzip" env:"GZIP" default:"true"`
+	CORS            bool          `yaml:"cors" env:"CORS" default:"true"`
+	Recovery        bool          `yaml:"recovery" env:"RECOVERY" default:"true"`
 }
 
 // LoggerConfig holds logging configuration
@@ -81,14 +82,15 @@ type Loader interface {
 func DefaultConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			Port:         "8080",
-			Address:      ":8080",
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 30 * time.Second,
-			IdleTimeout:  120 * time.Second,
-			GZip:         true,
-			CORS:         true,
-			Recovery:     true,
+			Port:            "8080",
+			Address:         ":8080",
+			ReadTimeout:     30 * time.Second,
+			WriteTimeout:    30 * time.Second,
+			IdleTimeout:     120 * time.Second,
+			ShutdownTimeout: 10 * time.Second,
+			GZip:            true,
+			CORS:            true,
+			Recovery:        true,
 		},
 		Logger: LoggerConfig{
 			Level:            "info",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "8080", cfg.Server.Port)
 	assert.Equal(t, ":8080", cfg.Server.Address)
 	assert.Equal(t, 30*time.Second, cfg.Server.ReadTimeout)
+	assert.Equal(t, 10*time.Second, cfg.Server.ShutdownTimeout)
 	assert.True(t, cfg.Server.Recovery)
 
 	// Test logger defaults
@@ -37,6 +38,7 @@ func TestSimpleLoader_LoadFromEnv(t *testing.T) {
 	os.Setenv("STMP_SERVER_PORT", "9090")
 	os.Setenv("STMP_SERVER_ADDRESS", ":9090")
 	os.Setenv("STMP_SERVER_GZIP", "false")
+	os.Setenv("STMP_SERVER_SHUTDOWN_TIMEOUT", "20s")
 	os.Setenv("STMP_LOGGER_LEVEL", "debug")
 	os.Setenv("STMP_WEBSOCKET_READ_BUFFER_SIZE", "2048")
 	os.Setenv("STMP_JWT_SECRET_KEY", "test-secret-key")
@@ -49,6 +51,7 @@ func TestSimpleLoader_LoadFromEnv(t *testing.T) {
 		os.Unsetenv("STMP_SERVER_PORT")
 		os.Unsetenv("STMP_SERVER_ADDRESS")
 		os.Unsetenv("STMP_SERVER_GZIP")
+		os.Unsetenv("STMP_SERVER_SHUTDOWN_TIMEOUT")
 		os.Unsetenv("STMP_LOGGER_LEVEL")
 		os.Unsetenv("STMP_WEBSOCKET_READ_BUFFER_SIZE")
 		os.Unsetenv("STMP_JWT_SECRET_KEY")
@@ -66,6 +69,7 @@ func TestSimpleLoader_LoadFromEnv(t *testing.T) {
 	assert.Equal(t, "9090", cfg.Server.Port)
 	assert.Equal(t, ":9090", cfg.Server.Address)
 	assert.False(t, cfg.Server.GZip)
+	assert.Equal(t, 20*time.Second, cfg.Server.ShutdownTimeout)
 	assert.Equal(t, "debug", cfg.Logger.Level)
 	assert.Equal(t, 2048, cfg.WebSocket.ReadBufferSize)
 	assert.Equal(t, "test-secret-key", cfg.JWT.SecretKey)
@@ -79,6 +83,7 @@ server:
   port: "8888"
   address: ":8888"
   gzip: false
+  shutdown_timeout: 5s
 logger:
   level: "warn"
 websocket:
@@ -112,6 +117,7 @@ database:
 	assert.Equal(t, 2048, cfg.WebSocket.ReadBufferSize)
 	assert.Equal(t, "yaml-secret", cfg.JWT.SecretKey)
 	assert.Equal(t, "yaml-issuer", cfg.JWT.Issuer)
+	assert.Equal(t, 5*time.Second, cfg.Server.ShutdownTimeout)
 }
 
 func TestSimpleLoader_EnvOverridesYAML(t *testing.T) {
@@ -119,6 +125,7 @@ func TestSimpleLoader_EnvOverridesYAML(t *testing.T) {
 	yamlContent := `
 server:
   port: "7777"
+  shutdown_timeout: 30s
 logger:
   level: "error"
 jwt:
@@ -137,7 +144,11 @@ database:
 
 	// Set environment variable to override YAML
 	os.Setenv("STMP_SERVER_PORT", "9999")
-	defer os.Unsetenv("STMP_SERVER_PORT")
+	os.Setenv("STMP_SERVER_SHUTDOWN_TIMEOUT", "15s")
+	defer func() {
+		os.Unsetenv("STMP_SERVER_PORT")
+		os.Unsetenv("STMP_SERVER_SHUTDOWN_TIMEOUT")
+	}()
 
 	// Load configuration
 	loader := config.NewSimpleLoader().WithYAMLFile(tmpFile.Name())
@@ -147,6 +158,7 @@ database:
 
 	// Environment variable should override YAML
 	assert.Equal(t, "9999", cfg.Server.Port)
+	assert.Equal(t, 15*time.Second, cfg.Server.ShutdownTimeout)
 	// YAML value should be loaded for non-overridden fields
 	assert.Equal(t, "error", cfg.Logger.Level)
 }
@@ -181,11 +193,13 @@ func TestLoadFromJSON(t *testing.T) {
 func TestSimpleLoader_WithEnvPrefix(t *testing.T) {
 	// Set environment variable with custom prefix
 	os.Setenv("MYAPP_SERVER_PORT", "5555")
+	os.Setenv("MYAPP_SERVER_SHUTDOWN_TIMEOUT", "25s")
 	os.Setenv("MYAPP_JWT_SECRET_KEY", "myapp-secret")
 	os.Setenv("MYAPP_DATABASE_USER", "myapp-user")
 	os.Setenv("MYAPP_DATABASE_PASSWORD", "myapp-pass")
 	defer func() {
 		os.Unsetenv("MYAPP_SERVER_PORT")
+		os.Unsetenv("MYAPP_SERVER_SHUTDOWN_TIMEOUT")
 		os.Unsetenv("MYAPP_JWT_SECRET_KEY")
 		os.Unsetenv("MYAPP_DATABASE_USER")
 		os.Unsetenv("MYAPP_DATABASE_PASSWORD")
@@ -197,4 +211,5 @@ func TestSimpleLoader_WithEnvPrefix(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "5555", cfg.Server.Port)
+	assert.Equal(t, 25*time.Second, cfg.Server.ShutdownTimeout)
 }

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -4,6 +4,7 @@ server:
   read_timeout: 30s
   write_timeout: 30s
   idle_timeout: 120s
+  shutdown_timeout: 10s
   gzip: true
   cors: true
   recovery: true


### PR DESCRIPTION
## Summary
- extend `ServerConfig` with `ShutdownTimeout`
- parse `shutdown_timeout` from env and yaml
- update tests for new option
- update example config with `shutdown_timeout`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_687f2c3c2918832db8f4dd7c94314b75