### PR TITLE
Clarify config prefix differences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,13 @@ err := loader.Load(cfg)
 - Backward compatible with SimpleLoader
 - Full validation support
 
+`SimpleLoader` still reads environment variables with the legacy `STMP_`
+prefix. `BofryLoader` and the builder pattern default to `GORTEX_`. To keep
+existing `STMP_` variables, pass `WithEnvPrefix("STMP_")` or construct the
+loader with `config.NewSimpleLoaderCompat()`. Helper functions like
+`config.LoadWithBofry` and `config.LoadFromDotEnv` are available to make the
+migration painless.
+
 ## Development Standards
 
 ### Code Conventions

--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ database:
   url: ${DATABASE_URL}
 ```
 
+**Prefix Compatibility**
+
+`SimpleLoader` continues to use the historical `STMP_` prefix when loading
+environment variables. The newer `BofryLoader` and the `ConfigBuilder`
+default to the `GORTEX_` prefix. If you have existing `STMP_` variables, call
+`WithEnvPrefix("STMP_")` on the loader or use `config.NewSimpleLoaderCompat()`
+as a drop-in replacement. Helpers such as `config.LoadWithBofry` and
+`config.LoadFromDotEnv` can further ease the transition.
+
 ### Observability
 
 ```go


### PR DESCRIPTION
## Summary
- mention in README that SimpleLoader uses `STMP_` while BofryLoader defaults to `GORTEX_`
- note the same prefix behavior in the Claude doc and show migration helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_687f33985294832d813f35af2a79183d