### PR TITLE
Replace deprecated strings.Title with cases.Title

### DIFF
--- a/cmd/gortex/commands/utils.go
+++ b/cmd/gortex/commands/utils.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func generateFile(path string, tmplContent string, data interface{}) error {
@@ -27,7 +30,7 @@ func generateFile(path string, tmplContent string, data interface{}) error {
 	funcMap := template.FuncMap{
 		"upper": strings.ToUpper,
 		"lower": strings.ToLower,
-		"title": strings.Title,
+		"title": cases.Title(language.Und).String,
 	}
 
 	tmpl, err := template.New("file").Funcs(funcMap).Parse(tmplContent)


### PR DESCRIPTION
## Summary
- import `golang.org/x/text/cases` and `golang.org/x/text/language`
- add `cases.Title(language.Und).String` helper to template FuncMap
- remove usage of deprecated `strings.Title`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_687f3652c824832db0a151dfcaf81df5