### PR TITLE
Add tests for dev server and scaffold output

### DIFF
--- a/cmd/gortex/commands/scaffold_test.go
+++ b/cmd/gortex/commands/scaffold_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitProjectCreatesAllFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	rootCmd = &cobra.Command{Version: "v0.0.0"}
+
+	err := initProject(tmpDir, "testapp", false)
+	require.NoError(t, err)
+
+	expected := []string{
+		"go.mod",
+		"cmd/server/main.go",
+		"config/config.yaml",
+		"handlers/manager.go",
+		"handlers/health.go",
+		"services/interfaces.go",
+		"README.md",
+		".gitignore",
+	}
+
+	for _, f := range expected {
+		_, err := os.Stat(filepath.Join(tmpDir, f))
+		require.NoError(t, err, f)
+	}
+}
+
+func TestInitProjectWithExamples(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	rootCmd = &cobra.Command{Version: "v0.0.0"}
+
+	err := initProject(tmpDir, "testapp", true)
+	require.NoError(t, err)
+
+	expected := []string{
+		"handlers/user.go",
+		"handlers/auth.go",
+		"handlers/websocket.go",
+		"services/user_service.go",
+		"models/user.go",
+	}
+
+	for _, f := range expected {
+		_, err := os.Stat(filepath.Join(tmpDir, f))
+		require.NoError(t, err, f)
+	}
+}

--- a/cmd/gortex/commands/server.go
+++ b/cmd/gortex/commands/server.go
@@ -15,6 +15,10 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+// execCommand is used to execute external commands. It is defined as a
+// variable so tests can replace it with a mock implementation.
+var execCommand = exec.Command
+
 func runDevServer(configPath, port string) error {
 	// Setup signal handling
 	sigChan := make(chan os.Signal, 1)
@@ -54,7 +58,7 @@ func runDevServer(configPath, port string) error {
 
 		// Build
 		fmt.Println("🔨 Building...")
-		buildCmd := exec.Command("go", "build", "-o", ".gortex-dev-server", "./cmd/server")
+		buildCmd := execCommand("go", "build", "-o", ".gortex-dev-server", "./cmd/server")
 		buildCmd.Stdout = os.Stdout
 		buildCmd.Stderr = os.Stderr
 		if err := buildCmd.Run(); err != nil {
@@ -64,16 +68,16 @@ func runDevServer(configPath, port string) error {
 
 		// Run
 		fmt.Printf("🚀 Starting server on port %s...\n", port)
-		cmd = exec.Command("./.gortex-dev-server")
+		cmd = execCommand("./.gortex-dev-server")
 		cmd.Env = append(os.Environ(), fmt.Sprintf("GORTEX_SERVER_ADDRESS=:%s", port))
 		if configPath != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("GORTEX_CONFIG_PATH=%s", configPath))
 		}
-		
+
 		// Pipe output
 		stdout, _ := cmd.StdoutPipe()
 		stderr, _ := cmd.StderrPipe()
-		
+
 		go io.Copy(os.Stdout, stdout)
 		go io.Copy(os.Stderr, stderr)
 
@@ -107,20 +111,20 @@ func runDevServer(configPath, port string) error {
 
 		case event := <-watcher.Events:
 			// Skip non-Go files and temporary files
-			if !strings.HasSuffix(event.Name, ".go") || 
-			   strings.Contains(event.Name, ".gortex-dev-server") ||
-			   strings.HasPrefix(filepath.Base(event.Name), ".") {
+			if !strings.HasSuffix(event.Name, ".go") ||
+				strings.Contains(event.Name, ".gortex-dev-server") ||
+				strings.HasPrefix(filepath.Base(event.Name), ".") {
 				continue
 			}
 
 			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
 				fmt.Printf("📝 File changed: %s\n", event.Name)
-				
+
 				// Cancel previous timer
 				if debounceTimer != nil {
 					debounceTimer.Stop()
 				}
-				
+
 				// Set new timer
 				debounceTimer = time.AfterFunc(debounceDuration, func() {
 					if time.Since(lastBuild) > debounceDuration {
@@ -140,16 +144,16 @@ func addWatchDir(watcher *fsnotify.Watcher, dir string) error {
 		if err != nil {
 			return err
 		}
-		
+
 		// Skip hidden directories and vendor
 		if info.IsDir() && (strings.HasPrefix(info.Name(), ".") || info.Name() == "vendor") {
 			return filepath.SkipDir
 		}
-		
+
 		if info.IsDir() {
 			return watcher.Add(path)
 		}
-		
+
 		return nil
 	})
 }

--- a/cmd/gortex/commands/server_test.go
+++ b/cmd/gortex/commands/server_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	execMu    sync.Mutex
+	execCalls [][]string
+)
+
+func fakeExecCommand(name string, args ...string) *exec.Cmd {
+	execMu.Lock()
+	execCalls = append(execCalls, append([]string{name}, args...))
+	execMu.Unlock()
+
+	cs := []string{"-test.run=TestHelperProcess", "--", name}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Exit(0)
+}
+
+func TestRunDevServer(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := []string{"handlers", "services", "models", "config", "cmd/server"}
+	for _, d := range dirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, d), 0755))
+	}
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(cwd)
+
+	execMu.Lock()
+	execCalls = nil
+	execMu.Unlock()
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	done := make(chan error)
+	go func() {
+		done <- runDevServer("", "1234")
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	p, _ := os.FindProcess(os.Getpid())
+	_ = p.Signal(os.Interrupt)
+
+	err = <-done
+	require.NoError(t, err)
+
+	execMu.Lock()
+	calls := append([][]string(nil), execCalls...)
+	execMu.Unlock()
+
+	require.Len(t, calls, 2)
+	require.Equal(t, []string{"go", "build", "-o", ".gortex-dev-server", "./cmd/server"}, calls[0])
+	require.Equal(t, []string{"./.gortex-dev-server"}, calls[1])
+}


### PR DESCRIPTION
## Summary
- allow injecting `exec.Command` in dev server
- add unit tests for `runDevServer` using fake commands
- verify `initProject` creates expected files with and without examples

## Testing
- `go test ./cmd/gortex/commands`

------
https://chatgpt.com/codex/tasks/task_b_687f3722f420832d8dd31c472e0cc28d