### PR TITLE
Extract actual middleware function names for logging

### DIFF
--- a/core/app/internal_coverage_test.go
+++ b/core/app/internal_coverage_test.go
@@ -45,8 +45,8 @@ func TestExtractMiddlewareNames(t *testing.T) {
 	noop := func(next middleware.HandlerFunc) middleware.HandlerFunc { return next }
 	got := extractMiddlewareNames([]middleware.MiddlewareFunc{noop, nil, noop})
 	// nil middleware is skipped; the two non-nil entries produce
-	// generic placeholder names derived from their slice index.
-	assert.Equal(t, []string{"middleware_0", "middleware_2"}, got)
+	// the actual function name derived from reflection.
+	assert.Equal(t, []string{"app.TestExtractMiddlewareNames.func1", "app.TestExtractMiddlewareNames.func1"}, got)
 	assert.Empty(t, extractMiddlewareNames(nil))
 }
 

--- a/core/app/route_registration.go
+++ b/core/app/route_registration.go
@@ -214,19 +214,12 @@ func registerMethodWithMiddleware(r httpctx.GortexRouter, httpMethod, path strin
 	// Collect route info if app is provided, logging is enabled, or dev mode is on.
 	if app != nil && (app.enableRoutesLog || app.developmentMode) {
 		handlerName := reflect.TypeOf(handler).Elem().Name()
-		var middlewareNames []string
-		// TODO: Extract middleware names - for now just count them
-		if len(middleware) > 0 {
-			middlewareNames = []string{fmt.Sprintf("%d middleware", len(middleware))}
-		} else {
-			middlewareNames = []string{}
-		}
 
 		app.routeInfos = append(app.routeInfos, RouteLogInfo{
 			Method:      httpMethod,
 			Path:        path,
 			Handler:     handlerName,
-			Middlewares: middlewareNames,
+			Middlewares: extractMiddlewareNames(middleware),
 		})
 	}
 
@@ -287,18 +280,12 @@ func registerCustomMethodWithMiddleware(r httpctx.GortexRouter, path string, han
 	// Collect route info for custom methods (same condition as standard methods).
 	if app != nil && (app.enableRoutesLog || app.developmentMode) {
 		handlerName := reflect.TypeOf(handler).Elem().Name()
-		var middlewareNames []string
-		if len(middleware) > 0 {
-			middlewareNames = []string{fmt.Sprintf("%d middleware", len(middleware))}
-		} else {
-			middlewareNames = []string{}
-		}
 
 		app.routeInfos = append(app.routeInfos, RouteLogInfo{
 			Method:      "POST", // Custom methods are always registered as POST.
 			Path:        path,
 			Handler:     handlerName + "." + method.Name,
-			Middlewares: middlewareNames,
+			Middlewares: extractMiddlewareNames(middleware),
 		})
 	}
 

--- a/core/app/utils.go
+++ b/core/app/utils.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"fmt"
 	"reflect"
+	"runtime"
 	"strings"
 
 	"github.com/yshengliao/gortex/middleware"
@@ -65,11 +65,16 @@ func methodNameToPath(name string) string {
 // extractMiddlewareNames extracts middleware names from a slice of middleware functions
 func extractMiddlewareNames(middlewares []middleware.MiddlewareFunc) []string {
 	names := make([]string, 0, len(middlewares))
-	for i, mw := range middlewares {
+	for _, mw := range middlewares {
 		if mw != nil {
-			// Try to extract name from function type
-			// Since Go doesn't provide function names at runtime, we use generic names
-			names = append(names, fmt.Sprintf("middleware_%d", i))
+			// Extract name from function pointer
+			name := runtime.FuncForPC(reflect.ValueOf(mw).Pointer()).Name()
+			// Clean up package path, just keep the last part
+			parts := strings.Split(name, "/")
+			name = parts[len(parts)-1]
+			// Optional: remove -fm (method value) suffix
+			name = strings.TrimSuffix(name, "-fm")
+			names = append(names, name)
 		}
 	}
 	return names


### PR DESCRIPTION
This commit resolves the issue where middleware logging would only display the count of applied middlewares. By utilizing `runtime.FuncForPC` via reflection, the actual function names of the middleware are now extracted and logged. This enhances route log visibility.

---
*PR created automatically by Jules for task [9398844039374153768](https://jules.google.com/task/9398844039374153768) started by @yshengliao*