### PR TITLE
Register global error handler middleware

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -272,6 +272,7 @@ func (app *App) setupRouter() {
 		app.router.Use(middleware.RecoverWithErrorPage())
 	}
 
+	// Register global error handler middleware
 	app.router.Use(middleware.ErrorHandlerWithConfig(&middleware.ErrorHandlerConfig{
 		Logger:                         app.logger,
 		HideInternalServerErrorDetails: !app.IsDevelopment(),


### PR DESCRIPTION
The global error handler middleware was already fully implemented and verified in `core/app/app.go` at the end of the `setupRouter` method. This submission adds a clear comment documenting the location to resolve any ambiguity related to the initial issue request.

---
*PR created automatically by Jules for task [3716038679534668081](https://jules.google.com/task/3716038679534668081) started by @yshengliao*