### PR TITLE
release: v0.8.1-alpha — actual middleware names in route logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); version
 
 ---
 
+## [v0.8.1-alpha] — 2026-06-19
+
+Patch release — no breaking changes.
+
+### Changed
+- **Route logging**: registered-route logging and the `/_routes` debug view now show the actual middleware function names, resolved via `runtime.FuncForPC`, instead of a placeholder count (`"N middleware"`) or index-based names (`middleware_0`). Package paths and the method-value `-fm` suffix are trimmed for readability. Affects `RouteLogInfo.Middlewares` in `core/app` (#26).
+
+---
+
 ## [v0.8.0-alpha] — 2026-06-10
 
 Third-round security and correctness audit. This release is a **minor bump** because it contains multiple breaking changes to the JWT, middleware-tag, and rate-limit APIs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Gortex Framework - Development Guide
 
-> **Framework**: Gortex | **Language**: Go 1.25 | **Status**: v0.8.0-alpha | **Updated**: 2026-06-10
+> **Framework**: Gortex | **Language**: Go 1.25 | **Status**: v0.8.1-alpha | **Updated**: 2026-06-19
 
 Development guide for Gortex — a high-performance Go web framework with declarative struct-tag routing.
 
@@ -316,4 +316,4 @@ handlers.UserService.DB = dbConnection
 
 ---
 
-**Last Updated**: 2026-06-10 | **Framework**: Gortex v0.8.0-alpha | **Go**: 1.25+
+**Last Updated**: 2026-06-19 | **Framework**: Gortex v0.8.1-alpha | **Go**: 1.25+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gortex - High-Performance Go Web Framework
 
 [![Go Version](https://img.shields.io/badge/go-1.25+-blue.svg)](https://go.dev/)
-![Status](https://img.shields.io/badge/status-v0.8.0--alpha-orange.svg)
+![Status](https://img.shields.io/badge/status-v0.8.1--alpha-orange.svg)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 ![AI Generated](https://img.shields.io/badge/AI_Generated-Antigravity-blueviolet.svg)
 

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -1,7 +1,7 @@
 # Gortex — 高效能 Go Web 框架
 
 [![Go Version](https://img.shields.io/badge/go-1.25+-blue.svg)](https://go.dev/)
-![Status](https://img.shields.io/badge/status-v0.8.0--alpha-orange.svg)
+![Status](https://img.shields.io/badge/status-v0.8.1--alpha-orange.svg)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 ![AI Generated](https://img.shields.io/badge/AI_Generated-Antigravity-blueviolet.svg)
 


### PR DESCRIPTION
## v0.8.1-alpha — patch release

Wraps the route-logging improvement merged in #26 and bumps the current-version stamps. **No breaking changes.**

### Included
- #26 — `core/app` route logging and the `/_routes` debug view now show the actual middleware function names (resolved via `runtime.FuncForPC`) instead of a placeholder count (`"N middleware"`) or index-based names (`middleware_0`). Package paths and the method-value `-fm` suffix are trimmed for readability.

### This PR
- `CHANGELOG.md`: new `## [v0.8.1-alpha]` section.
- Current-version stamps bumped to `v0.8.1-alpha` / `2026-06-19`: `CLAUDE.md` header + footer, `README.md` and `README_ZH_TW.md` status badges.
- Historical / "as of v0.8.0-alpha" references (SECURITY.md, feature-inventory headers, past changelog entries) left intact — those describe when a behaviour was introduced.

### 🏷️ Tag / release (manual follow-up)
Tag push and release creation are not available from this sandbox (tag push → 403; no create-release MCP tool). After merge, publish via GitHub UI (**Releases → Draft a new release → tag `v0.8.1-alpha` → target `main`**) or:
```bash
git fetch origin && git tag -a v0.8.1-alpha <merge-commit> -m "v0.8.1-alpha — route logging shows real middleware names (see CHANGELOG.md)"
git push origin v0.8.1-alpha
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dnfchVogWzgHnMC3e9LC5

---
_Generated by [Claude Code](https://claude.ai/code/session_015dnfchVogWzgHnMC3e9LC5)_