### PR TITLE
docs: fix benchmark claims and clarify implementation details in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ With `cfg.Logger.Level = "debug"`:
 - Request logging with body capture (request bodies only; response-body logging is not supported — `LogResponseBody` is a no-op)
 
 ### Performance Optimizations
-- **Zero-Allocation Routing**: 0 allocs/op for trie traversal on static, param, wildcard, and deep-param routes (~65 ns/op on Apple M3 Pro; numbers from a maintainer machine, not reproduced in CI — full request context setup adds ~3 allocs/op from map and response-writer initialization)
+- **Zero-Allocation Routing**: 0 allocs/op for trie traversal on static, param, wildcard, and deep-param routes (~65 ns/op on Apple M3 Pro; numbers from a maintainer machine, not reproduced in CI — full request context setup adds ~3 allocs/op from context map and `responseWriter` initialization)
 - **Context Pool**: Embedded `responseWriter` value eliminates per-request allocation
 - **Smart Params**: Inline [4]string array for ≤4 params; overflow to ordered slice (preserves insertion order)
 - **Segment-Trie Router**: Predictable O(segments) matching without regex backtracking
@@ -286,6 +286,7 @@ handlers.UserService.DB = dbConnection
 - **Examples Updated**: Verify affected examples still work
 - **Documentation Current**: Keep README.md performance metrics updated
 - **Zero Regressions**: `go test ./...` must pass before commits
+- **OpenAPI/Swagger**: Skeleton exists in `core/app/doc/`; spec generation is not yet functional — do not depend on it
 
 ### Performance Targets
 - **Routing**: ~65 ns/op trie traversal on Apple M3 Pro (not reproduced in CI; Linux/x86 runs ~275–315 ns/op with 3 allocs/op from context setup)
@@ -312,7 +313,6 @@ handlers.UserService.DB = dbConnection
 - ❌ Not implementing complex optimizations that confuse developers
 - ❌ Not sacrificing developer experience for minor gains
 - ❌ Not increasing learning curve unnecessarily
-- ❌ OpenAPI/Swagger spec generation: skeleton exists (`core/app/doc/`), not yet functional
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ type HandlersManager struct {
 
 ### Key Features
 - **Zero Dependencies**: No Redis, Kafka, external services
-- **Fast Routing**: Segment-trie router with zero-allocation hot path (~65 ns/op, 0 allocs/op per in-repo benchmarks on Apple M3 Pro)
+- **Fast Routing**: Segment-trie router with zero-allocation hot path (~65 ns/op, 0 allocs/op for trie traversal on Apple M3 Pro; not reproduced in CI — see Performance Optimizations)
 - **WebSocket Native**: First-class real-time support
 - **Type-Safe**: Compile-time route validation
 - **Auto-Initialization**: Handlers automatically initialized
@@ -142,9 +142,9 @@ With `cfg.Logger.Level = "debug"`:
 - Request logging with body capture (request bodies only; response-body logging is not supported — `LogResponseBody` is a no-op)
 
 ### Performance Optimizations
-- **Zero-Allocation Routing**: 0 allocs/op for static, param, wildcard, and deep-param routes (~65 ns/op per in-repo benchmarks on Apple M3 Pro)
+- **Zero-Allocation Routing**: 0 allocs/op for trie traversal on static, param, wildcard, and deep-param routes (~65 ns/op on Apple M3 Pro; numbers from a maintainer machine, not reproduced in CI — full request context setup adds ~3 allocs/op from map and response-writer initialization)
 - **Context Pool**: Embedded `responseWriter` value eliminates per-request allocation
-- **Smart Params**: Inline [4]string array for ≤4 params; overflow to map
+- **Smart Params**: Inline [4]string array for ≤4 params; overflow to ordered slice (preserves insertion order)
 - **Segment-Trie Router**: Predictable O(segments) matching without regex backtracking
 
 ## Testing
@@ -249,8 +249,7 @@ handlers.UserService.DB = dbConnection
 
 ### Completed Features (v0.8.0-alpha)
 **Core Features**
-- Struct tag routing with segment-trie router (zero-allocation hot path, 0 allocs/op, ~65 ns/op per in-repo benchmarks on Apple M3 Pro)
-- **Zero-allocation routing hot path** (0 allocs/op, ~65 ns/op on M3 Pro)
+- Struct tag routing with segment-trie router (zero-allocation trie traversal hot path, ~65 ns/op on Apple M3 Pro; not reproduced in CI)
 - WebSocket support with hub pattern, size limits, type whitelist, authoriser hook
 - JWT authentication with ≥32-byte secret enforcement
 - Zero-dependency config loader (YAML, .env, env vars, CLI args)
@@ -289,8 +288,8 @@ handlers.UserService.DB = dbConnection
 - **Zero Regressions**: `go test ./...` must pass before commits
 
 ### Performance Targets
-- **Routing**: <100 ns/op (currently ~65 ns/op, 0 allocs)
-- **Memory**: Zero allocations on routing hot path
+- **Routing**: ~65 ns/op trie traversal on Apple M3 Pro (not reproduced in CI; Linux/x86 runs ~275–315 ns/op with 3 allocs/op from context setup)
+- **Memory**: Zero allocations in trie traversal hot path; full request context setup adds ~3 allocs
 - **Throughput**: >10k RPS on standard hardware
 
 ## Framework Context
@@ -313,7 +312,8 @@ handlers.UserService.DB = dbConnection
 - ❌ Not implementing complex optimizations that confuse developers
 - ❌ Not sacrificing developer experience for minor gains
 - ❌ Not increasing learning curve unnecessarily
+- ❌ OpenAPI/Swagger spec generation: skeleton exists (`core/app/doc/`), not yet functional
 
 ---
 
-**Last Updated**: 2026-06-19 | **Framework**: Gortex v0.8.1-alpha | **Go**: 1.25+
+**Last Updated**: 2026-06-20 | **Framework**: Gortex v0.8.1-alpha | **Go**: 1.25+


### PR DESCRIPTION
## Summary

Audit of actual code vs. documentation revealed four inaccuracies in `CLAUDE.md`. All are corrected here — no code changes.

- **Benchmark platform caveat**: `65 ns/op, 0 allocs/op` claims now clearly scoped to Apple M3 Pro trie traversal and marked "not reproduced in CI". Linux/x86 baseline (~275–315 ns/op, 3 allocs/op from context setup) added to Performance Targets so contributors have a realistic baseline.
- **`overflow to map` → `overflow to ordered slice`**: `smart_params.go` uses `[]pathParam` (ordered slice), not a map. Docs were wrong.
- **Duplicate bullet removed**: "Completed Features" had two identical zero-allocation lines; collapsed to one with caveat.
- **OpenAPI skeleton noted**: `core/app/doc/` exists but is non-functional; added one line under "Not Goals" so contributors don't accidentally depend on it.

## Test plan

- [ ] `go test ./... -race -count=1` passes (docs-only change, no code touched)
- [ ] `grep -r "overflow to map" .` returns no results
- [ ] Performance Targets section accurately reflects both M3 Pro and Linux numbers


---
_Generated by [Claude Code](https://claude.ai/code/session_01HSSa4yzaN4QCCfFQND8dat)_